### PR TITLE
Update gemspec to allow Rails 5.2

### DIFF
--- a/attachinary.gemspec
+++ b/attachinary.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency 'rails', '>= 3.2', '< 5.2'
+  s.add_dependency 'rails', '>= 3.2', '<= 5.2'
   s.add_dependency 'cloudinary', '~> 1.8'
 
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
5.2 brings ActiveStorage which we want to migrate to, so let's see if this works.